### PR TITLE
Don't store exon tuples in a python dict, it's too slow. Switch to a …

### DIFF
--- a/deeptoolsintervals/parse.py
+++ b/deeptoolsintervals/parse.py
@@ -222,17 +222,17 @@ class GTF(object):
                 strand = 1
             score = cols[4]
 
-        # Ensure that the name is unique
-        if name in self.exons.keys():
+        # Ensure that the name is unique, this happens to already be stored in the C-level hashTable, which is good because python is painfully slow
+        if self.tree.hasTranscript(name):
             sys.stderr.write("Skipping {0}, an entry by this name already exists!\n".format(name))
             return False
         else:
             self.tree.addEntry(self.mungeChromosome(cols[0]), int(cols[1]), int(cols[2]), name, strand, self.labelIdx, score)
             if ncols != 12 or self.keepExons is False:
-                self.exons[name] = [(int(cols[1]), int(cols[2]))]
+                self.exons.append([(int(cols[1]), int(cols[2]))])
             else:
                 assert(len(cols) == 12)
-                self.exons[name] = parseExonBounds(int(cols[1]), int(cols[2]), int(cols[9]), cols[10], cols[11])
+                self.exons.append(parseExonBounds(int(cols[1]), int(cols[2]), int(cols[9]), cols[10], cols[11]))
         return True
 
     def parseBED(self, fp, line, ncols=3, labelColumn=None):
@@ -376,9 +376,9 @@ class GTF(object):
             return
 
         name = m.groups()[0]
-        if name in self.exons.keys():
+        if self.tree.hasTranscript(name):
             sys.stderr.write("Warning: {0} occurs more than once! Only using the first instance.\n".format(name))
-            self.transcriptIDduplicated.append(name)
+            self.transcriptIDduplicated = self.transcriptIDduplicated.union(set([name]))
             return
 
         if int(cols[3]) > int(cols[4]) or int(cols[3]) < 1:
@@ -402,7 +402,8 @@ class GTF(object):
         self.tree.addEntry(chrom, int(cols[3]) - 1, int(cols[4]), name, strand, self.labelIdx, score)
 
         # Exon bounds placeholder
-        self.exons[name] = []
+        if self.keepExons:
+            self.exons.append([])
 
     def parseGTFexon(self, cols):
         """
@@ -420,10 +421,13 @@ class GTF(object):
         name = m.groups()[0]
         if name in self.transcriptIDduplicated:
             return
-        if name not in self.exons.keys():
-            self.exons[name] = []
+        if not self.tree.hasTranscript(name):
+            self.exons.append([])
+            exonIdx = self.tree.storeTranscriptIdx(name)
+        else:
+            exonIdx = self.tree.getTranscriptIdx(name)
 
-        self.exons[name].append((int(cols[3]) - 1, int(cols[4])))
+        self.exons[exonIdx].append((int(cols[3]) - 1, int(cols[4])))
 
     def parseGTF(self, fp, line):
         """
@@ -538,9 +542,9 @@ class GTF(object):
         self.fname = []
         self.filename = ""
         self.chroms = []
-        self.exons = {}
+        self.exons = []
         self.labels = []
-        self.transcriptIDduplicated = []
+        self.transcriptIDduplicated = set()
         self.tree = tree.initTree()
         self.labelIdx = 0
         self.gene_id_regex = re.compile('(?:gene_id (?:\"([ \w\d"\-\.]+)\"|([ \w\d"\-\.]+))[;|\r|\n])')
@@ -674,10 +678,11 @@ class GTF(object):
             return None
 
         for i, o in enumerate(overlaps):
-            if o[2] not in self.exons.keys() or len(self.exons[o[2]]) == 0:
-                exons = [(o[0], o[1])]
+            if self.keepExons:
+                exonIdx = self.tree.getTranscriptIdx(o[2])
+                exons = sorted(self.exons[exonIdx])
             else:
-                exons = sorted(self.exons[o[2]])
+                exons = [(o[0], o[1])]
 
             if numericGroups:
                 overlaps[i] = (o[0], o[1], o[2], o[3], exons)

--- a/deeptoolsintervals/tree/gtf.c
+++ b/deeptoolsintervals/tree/gtf.c
@@ -25,6 +25,9 @@ GTFtree * initGTFtree() {
     t->htFeatures = initHT(128);
     t->htAttributes = initHT(128);
 
+    //This makes life slightly easier by pre-adding 'transcript_id' to t->htAttributes
+    if(addHTelement(t->htAttributes, "transcript_id") != 0) return NULL;
+
     return t;
 }
 

--- a/deeptoolsintervals/tree/tree.c
+++ b/deeptoolsintervals/tree/tree.c
@@ -343,6 +343,70 @@ error:
     return NULL;
 }
 
+PyObject *pyHasTranscript(pyGTFtree_t *self, PyObject *args) {
+    GTFtree *t = self->t;
+    char *name = NULL;
+    PyObject *rv = Py_False;
+
+    if(!(PyArg_ParseTuple(args, "s", &name))) {
+        PyErr_SetString(PyExc_RuntimeError, "pyHasTranscript received an invalid or missing argument!");
+        return NULL;
+    }
+
+    if(strExistsHT(t->htAttributes, name)) rv = Py_True;
+
+    Py_INCREF(rv);
+    return rv;
+}
+
+PyObject *pyStoreTranscriptIdx(pyGTFtree_t *self, PyObject *args) {
+    GTFtree *t = self->t;
+    char *name = NULL;
+    int32_t idx;
+    PyObject *out_idx = NULL;
+
+    if(!(PyArg_ParseTuple(args, "s", &name))) {
+        PyErr_SetString(PyExc_RuntimeError, "pyStoreTranscriptIdx received an invalid or missing argument!");
+        return NULL;
+    }
+
+    idx = addHTelement(t->htAttributes, name);
+    if(idx <= 0) {
+        PyErr_SetString(PyExc_RuntimeError, "pyStoreTranscriptIdx received an error while adding the transcript name to the hash table!");
+        return NULL;
+    }
+
+    //'transcript_id' will be the first entry
+    idx -= 1;
+
+    out_idx = PyLong_FromLong((long) idx);
+    return out_idx;
+}
+
+PyObject *pyGetTranscriptIdx(pyGTFtree_t *self, PyObject *args) {
+    GTFtree *t = self->t;
+    char *name = NULL;
+    int32_t idx;
+    PyObject *out_idx = NULL;
+
+    if(!(PyArg_ParseTuple(args, "s", &name))) {
+        PyErr_SetString(PyExc_RuntimeError, "pyGetTranscriptIdx received an invalid or missing argument!");
+        return NULL;
+    }
+
+    idx = str2valHT(t->htAttributes, name);
+    if(idx <= 0) {
+        PyErr_SetString(PyExc_RuntimeError, "pyGetTranscriptIdx received an error while adding the transcript name to the hash table!");
+        return NULL;
+    }
+
+    //'transcript_id' will be the first entry
+    idx -= 1;
+
+    out_idx = PyLong_FromLong((long) idx);
+    return out_idx;
+}
+
 #if PY_MAJOR_VERSION >= 3
 PyMODINIT_FUNC PyInit_tree(void) {
     PyObject *res;

--- a/deeptoolsintervals/tree/tree.h
+++ b/deeptoolsintervals/tree/tree.h
@@ -22,6 +22,10 @@ static PyObject *pyCountEntries(pyGTFtree_t *self, PyObject *args);
 static PyObject *pyFindOverlaps(pyGTFtree_t *self, PyObject *args);
 static PyObject *pyFindOverlappingFeatures(pyGTFtree_t *self, PyObject *args);
 static PyObject *pyIsTree(pyGTFtree_t *self, PyObject *args);
+
+static PyObject *pyHasTranscript(pyGTFtree_t *self, PyObject *args);
+static PyObject *pyStoreTranscriptIdx(pyGTFtree_t *self, PyObject *args);
+static PyObject *pyGetTranscriptIdx(pyGTFtree_t *self, PyObject *args);
 static void pyGTFDealloc(pyGTFtree_t *self);
 
 static PyMethodDef treeMethods[] = {
@@ -43,6 +47,12 @@ static PyMethodDef treeMethods[] = {
 "Find overlapping intervals\n"},
     {"findOverlappingFeatures", (PyCFunction) pyFindOverlappingFeatures, METH_VARARGS,
 "Find overlapping intervals, returning a list of features\n"},
+    {"hasTranscript", (PyCFunction) pyHasTranscript, METH_VARARGS,
+"Return whether a transcript is in the hash table\n"},
+    {"storeTranscriptIdx", (PyCFunction) pyStoreTranscriptIdx, METH_VARARGS,
+"Store the transcript name (or any other string) in the hash table\n"},
+    {"getTranscriptIdx", (PyCFunction) pyGetTranscriptIdx, METH_VARARGS,
+"Return the transcript index in the hash table\n"},
     {NULL, NULL, 0, NULL}
 };
 


### PR DESCRIPTION
…list with the key/index stored in the GTFtree attributes hash table

As an example, parsing the Ensembl release 75 GTF file with the previous method takes ~30 minutes. With this change, it's ~16 seconds.
